### PR TITLE
Feature/hu 12 listar pedidos

### DIFF
--- a/src/main/java/com/microservice/foodcourt/application/dto/response/DishOrderResponseDto.java
+++ b/src/main/java/com/microservice/foodcourt/application/dto/response/DishOrderResponseDto.java
@@ -1,0 +1,7 @@
+package com.microservice.foodcourt.application.dto.response;
+
+public record DishOrderResponseDto(
+         DishResponseDto dish,
+         Integer amount
+) {
+}

--- a/src/main/java/com/microservice/foodcourt/application/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/microservice/foodcourt/application/dto/response/OrderResponseDto.java
@@ -1,0 +1,17 @@
+package com.microservice.foodcourt.application.dto.response;
+
+import com.microservice.foodcourt.domain.model.OrderStatusModel;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record OrderResponseDto(
+        Long id,
+        Long customerId,
+        LocalDateTime date,
+        OrderStatusModel status ,
+        Long chefId,
+        RestaurantResponseDto restaurant,
+        List<DishOrderResponseDto> dishes
+) {
+}

--- a/src/main/java/com/microservice/foodcourt/application/handler/IOrderHandler.java
+++ b/src/main/java/com/microservice/foodcourt/application/handler/IOrderHandler.java
@@ -1,10 +1,14 @@
 package com.microservice.foodcourt.application.handler;
 
 import com.microservice.foodcourt.application.dto.request.OrderRequestDto;
+import com.microservice.foodcourt.application.dto.response.OrderResponseDto;
 import com.microservice.foodcourt.application.dto.response.SaveMessageResponse;
+import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 
 public interface IOrderHandler {
 
     SaveMessageResponse saveOrder(OrderRequestDto orderRequestDto);
+    PageResult<OrderResponseDto> getOrders(Integer page, Integer size, OrderStatusModel status);
 
 }

--- a/src/main/java/com/microservice/foodcourt/application/handler/impl/OrderHandler.java
+++ b/src/main/java/com/microservice/foodcourt/application/handler/impl/OrderHandler.java
@@ -1,10 +1,13 @@
 package com.microservice.foodcourt.application.handler.impl;
 
 import com.microservice.foodcourt.application.dto.request.OrderRequestDto;
+import com.microservice.foodcourt.application.dto.response.OrderResponseDto;
 import com.microservice.foodcourt.application.dto.response.SaveMessageResponse;
 import com.microservice.foodcourt.application.handler.IOrderHandler;
 import com.microservice.foodcourt.application.mapper.IOrderMapper;
 import com.microservice.foodcourt.domain.api.IOrderServicePort;
+import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,5 +26,10 @@ public class OrderHandler implements IOrderHandler {
     public SaveMessageResponse saveOrder(OrderRequestDto orderRequestDto) {
         orderServicePort.saveOrder(orderMapper.requestToModel(orderRequestDto));
         return new SaveMessageResponse("Pedido creado.", LocalDateTime.now());
+    }
+
+    @Override
+    public PageResult<OrderResponseDto> getOrders(Integer page, Integer size, OrderStatusModel status) {
+        return orderMapper.modelListToResponseList(orderServicePort.getOrders(page, size, status));
     }
 }

--- a/src/main/java/com/microservice/foodcourt/application/mapper/IOrderMapper.java
+++ b/src/main/java/com/microservice/foodcourt/application/mapper/IOrderMapper.java
@@ -1,7 +1,9 @@
 package com.microservice.foodcourt.application.mapper;
 
 import com.microservice.foodcourt.application.dto.request.OrderRequestDto;
+import com.microservice.foodcourt.application.dto.response.OrderResponseDto;
 import com.microservice.foodcourt.domain.model.OrderModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -18,5 +20,7 @@ public interface IOrderMapper {
     @Mapping(source = "restaurantId", target = "restaurant.id")
     @Mapping(source = "dishes", target = "dishes")
     OrderModel requestToModel(OrderRequestDto orderRequestDto);
+
+    PageResult<OrderResponseDto> modelListToResponseList(PageResult<OrderModel> orderModels);
 
 }

--- a/src/main/java/com/microservice/foodcourt/domain/api/IOrderServicePort.java
+++ b/src/main/java/com/microservice/foodcourt/domain/api/IOrderServicePort.java
@@ -1,9 +1,12 @@
 package com.microservice.foodcourt.domain.api;
 
 import com.microservice.foodcourt.domain.model.OrderModel;
+import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 
 public interface IOrderServicePort {
 
     void saveOrder(OrderModel orderModel);
+    PageResult<OrderModel> getOrders(Integer page, Integer size, OrderStatusModel status);
 
 }

--- a/src/main/java/com/microservice/foodcourt/domain/spi/IOrderPersistencePort.java
+++ b/src/main/java/com/microservice/foodcourt/domain/spi/IOrderPersistencePort.java
@@ -2,6 +2,7 @@ package com.microservice.foodcourt.domain.spi;
 
 import com.microservice.foodcourt.domain.model.OrderModel;
 import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 
 import java.util.List;
 
@@ -10,5 +11,8 @@ public interface IOrderPersistencePort {
     void saveOrder(OrderModel orderModel);
 
     void existsOrderInProcessByCustomerId(Long customerId, List<OrderStatusModel> status);
+
+    PageResult<OrderModel> getOrders(Integer page, Integer size, Long restaurantId, OrderStatusModel status);
+
 
 }

--- a/src/main/java/com/microservice/foodcourt/domain/spi/IRestaurantPersistencePort.java
+++ b/src/main/java/com/microservice/foodcourt/domain/spi/IRestaurantPersistencePort.java
@@ -10,4 +10,6 @@ public interface IRestaurantPersistencePort {
     void validateRestaurantOwnership(Long restaurantId, Long userId);
     PageResult<RestaurantModel> getRestaurants(Integer page, Integer size);
 
+    Long getRestaurantByEmployee(Long employeeId);
+
 }

--- a/src/main/java/com/microservice/foodcourt/domain/usecase/OrderUseCase.java
+++ b/src/main/java/com/microservice/foodcourt/domain/usecase/OrderUseCase.java
@@ -3,6 +3,8 @@ package com.microservice.foodcourt.domain.usecase;
 import com.microservice.foodcourt.domain.api.IOrderServicePort;
 import com.microservice.foodcourt.domain.model.OrderModel;
 import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
+import com.microservice.foodcourt.domain.model.RestaurantModel;
 import com.microservice.foodcourt.domain.spi.IDishPersistencePort;
 import com.microservice.foodcourt.domain.spi.IOrderPersistencePort;
 import com.microservice.foodcourt.domain.spi.IRestaurantPersistencePort;
@@ -47,5 +49,13 @@ public class OrderUseCase implements IOrderServicePort  {
         }
         dishPersistencePort.validateAllDishesBelongToRestaurant(dishesId, orderModel.getRestaurant().getId());
         orderPersistencePort.saveOrder(orderModel);
+    }
+
+    @Override
+    public PageResult<OrderModel> getOrders(Integer page, Integer size, OrderStatusModel status) {
+        Long employeeId = userSessionPort.getUserId();
+        Long restaurantIdByEmployee = restaurantPersistencePort.getRestaurantByEmployee(employeeId);
+        restaurantPersistencePort.validateExist(restaurantIdByEmployee);
+        return orderPersistencePort.getOrders(page, size, restaurantIdByEmployee, status);
     }
 }

--- a/src/main/java/com/microservice/foodcourt/domain/usecase/OrderUseCase.java
+++ b/src/main/java/com/microservice/foodcourt/domain/usecase/OrderUseCase.java
@@ -1,14 +1,15 @@
 package com.microservice.foodcourt.domain.usecase;
 
 import com.microservice.foodcourt.domain.api.IOrderServicePort;
+import com.microservice.foodcourt.domain.exception.InvalidPaginationParameterException;
 import com.microservice.foodcourt.domain.model.OrderModel;
 import com.microservice.foodcourt.domain.model.OrderStatusModel;
 import com.microservice.foodcourt.domain.model.PageResult;
-import com.microservice.foodcourt.domain.model.RestaurantModel;
 import com.microservice.foodcourt.domain.spi.IDishPersistencePort;
 import com.microservice.foodcourt.domain.spi.IOrderPersistencePort;
 import com.microservice.foodcourt.domain.spi.IRestaurantPersistencePort;
 import com.microservice.foodcourt.domain.spi.IUserSessionPort;
+import com.microservice.foodcourt.domain.utils.DomainConstants;
 
 import java.util.List;
 
@@ -53,6 +54,8 @@ public class OrderUseCase implements IOrderServicePort  {
 
     @Override
     public PageResult<OrderModel> getOrders(Integer page, Integer size, OrderStatusModel status) {
+        if (page < DomainConstants.PAGE_MIN) throw new InvalidPaginationParameterException(DomainConstants.INVALID_PAGE);
+        if (size < DomainConstants.SIZE_MIN) throw new InvalidPaginationParameterException(DomainConstants.INVALID_SIZE);
         Long employeeId = userSessionPort.getUserId();
         Long restaurantIdByEmployee = restaurantPersistencePort.getRestaurantByEmployee(employeeId);
         restaurantPersistencePort.validateExist(restaurantIdByEmployee);

--- a/src/main/java/com/microservice/foodcourt/infrastructure/clients/UserClient.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/clients/UserClient.java
@@ -1,6 +1,8 @@
 package com.microservice.foodcourt.infrastructure.clients;
 
+import com.microservice.foodcourt.infrastructure.dto.RestaurantIdResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -10,5 +12,8 @@ public interface UserClient {
 
     @GetMapping("/{userId}")
     void validateUser(@PathVariable Long userId, @RequestParam String role);
+
+    @GetMapping("/{userId}/restaurant")
+    public RestaurantIdResponseDto getRestaurantByEmployee(@PathVariable Long userId);
 
 }

--- a/src/main/java/com/microservice/foodcourt/infrastructure/clients/UserClient.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/clients/UserClient.java
@@ -2,7 +2,6 @@ package com.microservice.foodcourt.infrastructure.clients;
 
 import com.microservice.foodcourt.infrastructure.dto.RestaurantIdResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/microservice/foodcourt/infrastructure/dto/RestaurantIdResponseDto.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/dto/RestaurantIdResponseDto.java
@@ -1,0 +1,6 @@
+package com.microservice.foodcourt.infrastructure.dto;
+
+public record RestaurantIdResponseDto (
+        Long restaurantId
+){
+}

--- a/src/main/java/com/microservice/foodcourt/infrastructure/input/rest/OrderRestController.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/input/rest/OrderRestController.java
@@ -1,16 +1,16 @@
 package com.microservice.foodcourt.infrastructure.input.rest;
 
 import com.microservice.foodcourt.application.dto.request.OrderRequestDto;
+import com.microservice.foodcourt.application.dto.response.OrderResponseDto;
 import com.microservice.foodcourt.application.dto.response.SaveMessageResponse;
 import com.microservice.foodcourt.application.handler.IOrderHandler;
+import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("api/v1/order")
@@ -23,6 +23,13 @@ public class OrderRestController {
     @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<SaveMessageResponse> saveOrder(@RequestBody OrderRequestDto orderRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(orderHandler.saveOrder(orderRequestDto));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    public ResponseEntity<PageResult<OrderResponseDto>> getOrders(Integer page, Integer size, OrderStatusModel status) {
+        PageResult<OrderResponseDto> orderResponseDtoPageResult = orderHandler.getOrders(page, size, status);
+        return ResponseEntity.ok(orderResponseDtoPageResult);
     }
 
 }

--- a/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/adapter/OrderJpaMapper.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/adapter/OrderJpaMapper.java
@@ -3,6 +3,7 @@ package com.microservice.foodcourt.infrastructure.out.jpa.adapter;
 import com.microservice.foodcourt.domain.model.DishOrderModel;
 import com.microservice.foodcourt.domain.model.OrderModel;
 import com.microservice.foodcourt.domain.model.OrderStatusModel;
+import com.microservice.foodcourt.domain.model.PageResult;
 import com.microservice.foodcourt.domain.spi.IOrderPersistencePort;
 import com.microservice.foodcourt.infrastructure.exception.CustomerHasOngoingOrderException;
 import com.microservice.foodcourt.infrastructure.exception.NoDataFoundException;
@@ -12,6 +13,9 @@ import com.microservice.foodcourt.infrastructure.out.jpa.repository.IDishReposit
 import com.microservice.foodcourt.infrastructure.out.jpa.repository.IOrderRepository;
 import com.microservice.foodcourt.infrastructure.out.jpa.repository.IRestaurantRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,6 +56,20 @@ public class OrderJpaMapper implements IOrderPersistencePort {
         if (orderRepository.existsByCustomerIdAndStatuses(customerId, orderStatusEntities)) {
             throw new CustomerHasOngoingOrderException();
         }
+    }
+
+    @Override
+    public PageResult<OrderModel> getOrders(Integer page, Integer size, Long restaurantId, OrderStatusModel status) {
+        Pageable paging = PageRequest.of(page, size);
+        Page<OrderEntity> orderPage = orderRepository.findAllByRestaurant(restaurantId, orderEntityMapper.toOrderStatusEntity(status), paging);
+        List<OrderModel> orderList = orderEntityMapper.listEntityToListModel(orderPage.getContent());
+        return new PageResult<>(
+                orderList,
+                orderPage.getNumber(),
+                orderPage.getSize(),
+                orderPage.getTotalPages(),
+                orderPage.getTotalElements()
+        );
     }
 
 }

--- a/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/adapter/RestaurantJpaAdapter.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/adapter/RestaurantJpaAdapter.java
@@ -4,6 +4,7 @@ import com.microservice.foodcourt.domain.model.PageResult;
 import com.microservice.foodcourt.domain.model.RestaurantModel;
 import com.microservice.foodcourt.domain.spi.IRestaurantPersistencePort;
 import com.microservice.foodcourt.infrastructure.clients.UserClient;
+import com.microservice.foodcourt.infrastructure.dto.RestaurantIdResponseDto;
 import com.microservice.foodcourt.infrastructure.exception.NoDataFoundException;
 import com.microservice.foodcourt.infrastructure.exception.UnauthorizedException;
 import com.microservice.foodcourt.infrastructure.out.jpa.entity.RestaurantEntity;
@@ -61,6 +62,12 @@ public class RestaurantJpaAdapter implements IRestaurantPersistencePort {
                 pageRestaurant.getTotalPages(),
                 pageRestaurant.getTotalElements()
         );
+    }
+
+    @Override
+    public Long getRestaurantByEmployee(Long employeeId) {
+        RestaurantIdResponseDto restaurantIdResponseDto = userClient.getRestaurantByEmployee(employeeId);
+        return restaurantIdResponseDto.restaurantId();
     }
 
 }

--- a/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/mapper/IDishOrderEntityMapper.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/mapper/IDishOrderEntityMapper.java
@@ -1,0 +1,20 @@
+package com.microservice.foodcourt.infrastructure.out.jpa.mapper;
+
+import com.microservice.foodcourt.domain.model.DishOrderModel;
+import com.microservice.foodcourt.infrastructure.out.jpa.entity.DishOrderEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        unmappedSourcePolicy = ReportingPolicy.IGNORE
+)
+public interface IDishOrderEntityMapper {
+
+    @Mapping(target = "order", ignore = true)
+    DishOrderModel toModel(DishOrderEntity entity);
+
+    DishOrderEntity toEntity(DishOrderModel model);
+}

--- a/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/mapper/IOrderEntityMapper.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/mapper/IOrderEntityMapper.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 @Mapper(
         componentModel = "spring",
+        uses = { IDishOrderEntityMapper.class },
         unmappedSourcePolicy = ReportingPolicy.IGNORE,
         unmappedTargetPolicy = ReportingPolicy.IGNORE
 )
@@ -18,6 +19,10 @@ public interface IOrderEntityMapper {
 
     OrderEntity toEntity(OrderModel orderModel);
 
+    OrderStatusEntity toOrderStatusEntity(OrderStatusModel orderStatusModel);
+
     List<OrderStatusEntity> toOrderStatusList(List<OrderStatusModel> orderStatusModels);
+
+    List<OrderModel> listEntityToListModel(List<OrderEntity> orderEntities);
 
 }

--- a/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/repository/IOrderRepository.java
+++ b/src/main/java/com/microservice/foodcourt/infrastructure/out/jpa/repository/IOrderRepository.java
@@ -3,8 +3,12 @@ package com.microservice.foodcourt.infrastructure.out.jpa.repository;
 import com.microservice.foodcourt.domain.model.OrderStatusModel;
 import com.microservice.foodcourt.infrastructure.out.jpa.entity.OrderEntity;
 import com.microservice.foodcourt.infrastructure.out.jpa.entity.OrderStatusEntity;
+import com.microservice.foodcourt.infrastructure.out.jpa.entity.RestaurantEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,5 +17,9 @@ public interface IOrderRepository extends JpaRepository<OrderEntity, Long> {
 
     @Query("SELECT COUNT(o) > 0 FROM OrderEntity o WHERE o.customerId = ?1 AND o.status IN ?2")
     boolean existsByCustomerIdAndStatuses(Long customerId, List<OrderStatusEntity> orderStatus);
+
+    @Query("SELECT o FROM OrderEntity o WHERE o.restaurant.id = :restaurantId AND (:status IS NULL OR o.status = :status)")
+    Page<OrderEntity> findAllByRestaurant(@Param("restaurantId") Long restaurantId, @Param("status") OrderStatusEntity status, Pageable paging);
+
 
 }


### PR DESCRIPTION
Visualización de pedidos por estado para empleados de restaurante

Se implementa endpoint para listar pedidos filtrando por estado.

La lista está paginada y permite definir la cantidad de elementos por página.

Se incluyen todos los campos del pedido en la respuesta.

Solo se listan los pedidos del restaurante asociado al empleado autenticado.